### PR TITLE
Fix URL parameters for GetLyrics and HasLyrics

### DIFF
--- a/lyrics.go
+++ b/lyrics.go
@@ -31,7 +31,7 @@ type LyricResponse struct {
 }
 
 func GetLyrics(adamID string, region string, language string, token string, musicToken string) (string, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://amp-api.music.apple.com/v1/catalog/%s/songs/%s/syllable-lyrics?l[lyrics]=%s&extend=ttmlLocalizations&l[script]=en-Latn", region, adamID, language), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://amp-api.music.apple.com/v1/catalog/%s/songs/%s/syllable-lyrics?l=%s&extend=ttmlLocalizations", region, adamID, language), nil)
 	if err != nil {
 		return "", err
 	}
@@ -68,7 +68,7 @@ func GetLyrics(adamID string, region string, language string, token string, musi
 }
 
 func HasLyrics(adamID string, region string, language string, token string, musicToken string) bool {
-	req, err := http.NewRequest("HEAD", fmt.Sprintf("https://amp-api.music.apple.com/v1/catalog/%s/songs/%s/syllable-lyrics?l[lyrics]=%s&extend=ttmlLocalizations&l[script]=en-Latn", region, adamID, language), nil)
+	req, err := http.NewRequest("HEAD", fmt.Sprintf("https://amp-api.music.apple.com/v1/catalog/%s/songs/%s/syllable-lyrics?l=%s&extend=ttmlLocalizations", region, adamID, language), nil)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
i was getting the bug below so i made a fix 
```
> dl https://music.apple.com/vn/song/remember/1869843659
2026-03-14 09:32:27.942 | SONG | yuigot & Yachiyo Runami(cv.Saori Hayami) - Remember | INFO - Start ripping...
2026-03-14 09:32:29.476 | WARNING - Retrying src.grpc.manager.WrapperManager.lyrics in 0.68 seconds as it raised WrapperManagerException: failed to get lyrics.
2026-03-14 09:32:30.377 | WARNING - Retrying src.grpc.manager.WrapperManager.lyrics in 0.822 seconds as it raised WrapperManagerException: failed to get lyrics.
2026-03-14 09:32:31.421 | WARNING - Retrying src.grpc.manager.WrapperManager.lyrics in 1.27 seconds as it raised WrapperManagerException: failed to get lyrics.
2026-03-14 09:32:32.919 | WARNING - Retrying src.grpc.manager.WrapperManager.lyrics in 3.95 seconds as it raised WrapperManagerException: failed to get lyrics.
2026-03-14 09:32:37.098 | WARNING - Retrying src.grpc.manager.WrapperManager.lyrics in 9.37 seconds as it raised WrapperManagerException: failed to get lyrics.
```

```
wrapper-manager    | time="2026-03-14T02:32:17Z" level=info msg="[wrapper c686ed17] Wrapper ready"
wrapper-manager    | time="2026-03-14T02:32:23Z" level=info msg="decrypt stream from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:23Z" level=info msg="status request from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:28Z" level=info msg="lyrics request from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:30Z" level=info msg="lyrics request from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:31Z" level=info msg="lyrics request from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:32Z" level=info msg="lyrics request from 192.168.1.69:56308"
wrapper-manager    | time="2026-03-14T02:32:36Z" level=info msg="lyrics request from 192.168.1.69:56308"
```