### PR TITLE
fix: set wrapper compose permissions and mirror flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     command: [
       "--host", "0.0.0.0",
       "--port", "8080",
-      "--mirror", "false"
+      "--mirror=false"
     ]
+    privileged: true
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
Fixes the default Docker Compose setup for wrapper-manager.

## Changes
- Run the wrapper-manager service with `privileged: true`
- Pass the mirror option as `--mirror=false` instead of `--mirror`, `false`

## Why
The current Compose file can enable mirror mode unintentionally. In my test this caused wrapper download/extraction to fail with:

```text
panic: zip: not a valid zip file
```

After fixing the mirror flag, login still failed because the wrapper process exited immediately and wrapper-manager reported "wrapper down". 

With debug logging enabled, the wrapper output showed:

```text
unshare: Operation not permitted
```

The wrapper repository documents Docker usage with --privileged, so wrapper-manager's Compose service needs the same permissions when it runs wrapper inside the container.

## Testing
I tested a fresh wrapper-manager Docker Compose setup locally:
- default Compose: wrapper download failed
- --mirror=false: wrapper downloaded correctly, but login still failed with wrapper down
- --mirror=false + privileged: true: login successful